### PR TITLE
Update interface.rb

### DIFF
--- a/lib/marketo/interface.rb
+++ b/lib/marketo/interface.rb
@@ -129,7 +129,7 @@ module Marketo
   end
 
   class AuthenticationHeader
-    DIGEST = OpenSSL::Digest::Digest.new('sha1')
+    DIGEST = OpenSSL::Digest.new('sha1')
 
     def initialize(access_key, secret_key, time = DateTime.now)
       @access_key = access_key


### PR DESCRIPTION
Removes deprecated access to Digest. This raises a deprecation warning in ruby 2.1.
