### PR TITLE
Setting to use more current savon versions

### DIFF
--- a/lib/marketo/version.rb
+++ b/lib/marketo/version.rb
@@ -1,3 +1,3 @@
 module Marketo
-  VERSION = "0.0.2"
+  VERSION = "1.0.2"
 end

--- a/marketo.gemspec
+++ b/marketo.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('savon')
-  s.add_dependency('savon_model')
+  s.add_dependency('savon', '>= 0.9.7')
+  s.add_dependency('savon_model', '>= 1.2.0')
   s.add_development_dependency('vcr')
   s.add_development_dependency('rspec')
   s.add_development_dependency('webmock')


### PR DESCRIPTION
Sync client call was failing when a gemfile set the savon version to
0.9.2 using this version (0.9.7) works so lets roll with that.
